### PR TITLE
margin for topmenu

### DIFF
--- a/frontend/css/main.css
+++ b/frontend/css/main.css
@@ -3,6 +3,7 @@ html {
     min-height: 100%;
 }
 body {
+    margin-top: 70px;
     margin-bottom: 70px; /* 50 for footer + 20 margin */
 }
 


### PR DESCRIPTION
added body margin-top 70px. According to documentation padding should be used, however margin-bottom was already in use so to keep things consistent choose to use margin-top
